### PR TITLE
allow v0.6 of Trixi.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ version = "0.1.0-pre"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
-Trixi = "0.5.17"
+Trixi = "0.5.17, 0.6"
 julia = "1.8"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,4 +3,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
-Trixi = "0.5"
+Trixi = "0.5, 0.6"


### PR DESCRIPTION
Our CI tests of the v0.6 development branch fail because of this