### PR TITLE
Add spell check and format check workflows

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,44 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+  pull_request:
+
+jobs:
+  check-format:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - uses: actions/checkout@v4
+      - name: Install JuliaFormatter and format
+        # This will use the latest version by default but you can set the version like so:
+        #
+        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version = "0.13.0"))'
+        #
+        # TODO: Change the call below to
+        #       format(".")
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(["examples", "src", "test"])'
+      - name: Format check
+        run: |
+          julia -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "Some files have not been formatted !!!"
+              write(stdout, out)
+              exit(1)
+          end'

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -25,12 +25,9 @@ jobs:
         # This will use the latest version by default but you can set the version like so:
         #
         # julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version = "0.13.0"))'
-        #
-        # TODO: Change the call below to
-        #       format(".")
         run: |
           julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(["examples", "src", "test"])'
+          julia  -e 'using JuliaFormatter; format(".")'
       - name: Format check
         run: |
           julia -e '

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,13 @@
+name: Spell Check
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  typos-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Check spelling
+        uses: crate-ci/typos@v1.16.26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,25 +1,23 @@
 using TrixiShallowWater
 using Documenter
 
-DocMeta.setdocmeta!(TrixiShallowWater, :DocTestSetup, :(using TrixiShallowWater); recursive=true)
+DocMeta.setdocmeta!(TrixiShallowWater, :DocTestSetup, :(using TrixiShallowWater);
+                    recursive = true)
 
 makedocs(;
-    modules=[TrixiShallowWater],
-    authors="Andrew R. Winters <andrew.ross.winters@liu.se>, Michael Schlottke-Lakemper <michael@sloede.com>",
-    repo="https://github.com/trixi-framework/TrixiShallowWater.jl/blob/{commit}{path}#{line}",
-    sitename="TrixiShallowWater.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://trixi-framework.github.io/TrixiShallowWater.jl",
-        edit_link="main",
-        assets=String[],
-    ),
-    pages=[
-        "Home" => "index.md",
-    ],
-)
+         modules = [TrixiShallowWater],
+         authors = "Andrew R. Winters <andrew.ross.winters@liu.se>, Michael Schlottke-Lakemper <michael@sloede.com>",
+         repo = "https://github.com/trixi-framework/TrixiShallowWater.jl/blob/{commit}{path}#{line}",
+         sitename = "TrixiShallowWater.jl",
+         format = Documenter.HTML(;
+                                  prettyurls = get(ENV, "CI", "false") == "true",
+                                  canonical = "https://trixi-framework.github.io/TrixiShallowWater.jl",
+                                  edit_link = "main",
+                                  assets = String[],),
+         pages = [
+             "Home" => "index.md",
+         ],)
 
 deploydocs(;
-    repo="github.com/trixi-framework/TrixiShallowWater.jl",
-    devbranch="main",
-)
+           repo = "github.com/trixi-framework/TrixiShallowWater.jl",
+           devbranch = "main",)

--- a/src/equations/shallow_water_wet_dry_1d.jl
+++ b/src/equations/shallow_water_wet_dry_1d.jl
@@ -97,7 +97,7 @@ end
 
 # This equation set extends the basic ShallowWaterEquations1D from Trixi.jl with additional functionality
 # for wet/dry transitions. Since many functions correspond to the fully wet case, we make use of the
-# exisiting functionality and introduce a number of wrapper functions, that dispatch to the 
+# existing functionality and introduce a number of wrapper functions, that dispatch to the 
 # ShallowWaterEquations1D. 
 
 # Set initial conditions at physical location `x` for time `t`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,8 +23,8 @@ const TRIXI_NTHREADS = clamp(Sys.CPU_THREADS, 2, 3)
                 @test !(name in names(TrixiShallowWater))
             end
         end
-        
+
         # Run upstream tests for each mesh and dimension to test compatibility with Trixi.jl
-        include("test_upstream.jl")       
+        include("test_upstream.jl")
     end
 end

--- a/test/test_upstream.jl
+++ b/test/test_upstream.jl
@@ -20,7 +20,7 @@ isdir(outdir) && rm(outdir, recursive = true)
     # Shallow water wet/dry 1D
     @trixi_testset "1D-Test: elixir_shallowwater_well_balanced_nonperiodic.jl with wall boundary" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "tree_1d_dgsem",
-                                    "elixir_shallowwater_well_balanced_nonperiodic.jl"),
+                                     "elixir_shallowwater_well_balanced_nonperiodic.jl"),
                             l2=[
                                 1.7259643614361866e-8,
                                 3.5519018243195145e-16,


### PR DESCRIPTION
This PR introduces workflows for spell checking and format checking as done in `Trixi.jl`.
Furthermore, the PR sets additional permissions in `ci.yml` that are probably needed to delete old caches.