### PR TITLE
Speed up CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
           - '1.10'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
         trixi_test:
@@ -56,6 +54,14 @@ jobs:
           - unstructured_2d
           - unit
           - upstream
+        include:
+          - version: '1.10'
+            os: 
+              - macOS-latest
+              - windows-latest
+            arch: x64
+            trixi_test:
+              - upstream
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -72,8 +78,36 @@ jobs:
         env:
           PYTHON: ""
           TRIXI_TEST: ${{ matrix.trixi_test }}
+
+  test_coverage:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: coverage - ${{ matrix.trixi_test }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        trixi_test:
+          - tree_1d
+          - tree_2d
+          - structured_2d
+          - unstructured_2d
+          - unit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Run tests with coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.version == '1.10'
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: true
@@ -81,22 +115,16 @@ jobs:
           PYTHON: ""
           TRIXI_TEST: ${{ matrix.trixi_test }}
       - name: Process coverage results
-        # Only run coverage on Ubuntu
-        if: matrix.os == 'ubuntu-latest'
         uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,examples
       - name: Upload coverage report to Codecov
-        # Only run coverage on Ubuntu
-        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4
         with:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # now required for public repos
       - name: Upload coverage report to Coveralls
-        # Only run coverage on Ubuntu
-        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,13 @@ jobs:
           - upstream
         include:
           - version: '1.10'
-            os: 
-              - macOS-latest
-              - windows-latest
+            os: macOS-latest
             arch: x64
-            trixi_test:
-              - upstream
+            trixi_test: upstream
+          - version: '1.10'
+            os: windows-latest
+            arch: x64
+            trixi_test: upstream
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
           - upstream
         include:
           - version: '1.10'
-            os: macOS-latest
-            arch: x64
+            os: macos-latest
+            arch: aarch64
             trixi_test: upstream
           - version: '1.10'
             os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -49,6 +49,13 @@ jobs:
           - windows-latest
         arch:
           - x64
+        trixi_test:
+          - tree_1d
+          - tree_2d
+          - structured_2d
+          - unstructured_2d
+          - unit
+          - upstream
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -62,19 +69,35 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: false
+        env:
+          PYTHON: ""
+          TRIXI_TEST: ${{ matrix.trixi_test }}
       - name: Run tests with coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.version == '1.10'
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: true
-      - uses: julia-actions/julia-processcoverage@v1
+        env:
+          PYTHON: ""
+          TRIXI_TEST: ${{ matrix.trixi_test }}
+      - name: Process coverage results
+        # Only run coverage on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,examples
-      - uses: codecov/codecov-action@v4
+      - name: Upload coverage report to Codecov
+        # Only run coverage on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v4
         with:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # now required for public repos
-      - uses: coverallsapp/github-action@v2
+      - name: Upload coverage report to Coveralls
+        # Only run coverage on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,23 @@ using Test
 const TRIXI_TEST = get(ENV, "TRIXI_TEST", "all")
 
 @time @testset "TrixiShallowWater.jl tests" begin
-    @time if TRIXI_TEST == "all"
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "tree_1d"
         include("test_tree_1d.jl")
+    end
+
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "tree_2d"
         include("test_tree_2d.jl")
+    end
+
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "unstructured_2d"
         include("test_unstructured_2d.jl")
+    end
+
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "structured_2d"
         include("test_structured_2d.jl")
+    end
+
+    @time if TRIXI_TEST == "all" || TRIXI_TEST == "unit"
         include("test_unit.jl")
     end
 


### PR DESCRIPTION
With the additional features being added having a single CI job became very slow.
This PR should speed up the CI time by splitting the tests into multiple jobs. Furthermore, `macOS` and `windows` tests will run without coverage and become restricted to the `upstream` testset.