### PR TITLE
Fix Zhang-Shu limiter on curved meshes

### DIFF
--- a/src/callbacks_stage/positivity_shallow_water_dg2d.jl
+++ b/src/callbacks_stage/positivity_shallow_water_dg2d.jl
@@ -12,6 +12,7 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                                 equations::ShallowWaterEquationsWetDry2D, dg::DGSEM,
                                 cache)
     @unpack weights = dg.basis
+    @unpack inverse_jacobian = cache.elements
 
     Trixi.@threaded for element in eachelement(dg, cache)
         # determine minimum value
@@ -26,12 +27,16 @@ function limiter_shallow_water!(u, threshold::Real, variable,
 
         # compute mean value
         u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+        total_volume = zero(eltype(u))
         for j in eachnode(dg), i in eachnode(dg)
+            volume_jacobian = abs(inv(Trixi.get_inverse_jacobian(inverse_jacobian, mesh,
+                                                                 i, j, element)))
             u_node = get_node_vars(u, equations, dg, i, j, element)
-            u_mean += u_node * weights[i] * weights[j]
+            u_mean += u_node * weights[i] * weights[j] * volume_jacobian
+            total_volume += weights[i] * weights[j] * volume_jacobian
         end
-        # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-        u_mean = u_mean / 2^ndims(mesh)
+        # normalize with the total volume
+        u_mean = u_mean / total_volume
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
@@ -96,6 +101,7 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                                 equations::ShallowWaterMultiLayerEquations2D, dg::DGSEM,
                                 cache)
     @unpack weights = dg.basis
+    @unpack inverse_jacobian = cache.elements
 
     Trixi.@threaded for element in eachelement(dg, cache)
         # Limit layerwise
@@ -112,12 +118,17 @@ function limiter_shallow_water!(u, threshold::Real, variable,
 
             # compute mean value
             u_mean = zero(get_node_vars(u, equations, dg, 1, 1, element))
+            total_volume = zero(eltype(u))
             for j in eachnode(dg), i in eachnode(dg)
+                volume_jacobian = abs(inv(Trixi.get_inverse_jacobian(inverse_jacobian,
+                                                                     mesh,
+                                                                     i, j, element)))
                 u_node = get_node_vars(u, equations, dg, i, j, element)
-                u_mean += u_node * weights[i] * weights[j]
+                u_mean += u_node * weights[i] * weights[j] * volume_jacobian
+                total_volume += weights[i] * weights[j] * volume_jacobian
             end
-            # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-            u_mean = u_mean / 2^ndims(mesh)
+            # normalize with the total volume
+            u_mean = u_mean / total_volume
 
             # We compute the value directly with the mean values.
             # The waterheight `h` is limited independently in each layer.


### PR DESCRIPTION
This fixes a bug in the mean value computation that caused conservation issues on curved meshes.
See https://github.com/trixi-framework/Trixi.jl/pull/1945