### PR TITLE
Fix for failing CI tests

### DIFF
--- a/examples/structured_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
+++ b/examples/structured_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
@@ -176,7 +176,7 @@ function lake_at_rest_error_two_level(u, x, equations::ShallowWaterEquationsWetD
 end
 
 # point to the data we want to analyze
-u = Trixi.wrap_array(sol[end], semi)
+u = Trixi.wrap_array(sol.u[end], semi)
 # Perform the actual integration of the well-balancedness error over the domain
 l1_well_balance_error = Trixi.integrate_via_indices(u, mesh, equations, semi.solver,
                                                     semi.cache;

--- a/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
@@ -141,7 +141,7 @@ function lake_at_rest_error_two_level(u, x, equations::ShallowWaterEquationsWetD
 end
 
 # point to the data we want to analyze
-u = Trixi.wrap_array(sol[end], semi)
+u = Trixi.wrap_array(sol.u[end], semi)
 # Perform the actual integration of the well-balancedness error over the domain
 l1_well_balance_error = Trixi.integrate_via_indices(u, mesh, equations, semi.solver,
                                                     semi.cache;

--- a/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
@@ -175,7 +175,7 @@ function lake_at_rest_error_two_level(u, x, equations::ShallowWaterEquationsWetD
 end
 
 # point to the data we want to analyze
-u = Trixi.wrap_array(sol[end], semi)
+u = Trixi.wrap_array(sol.u[end], semi)
 # Perform the actual integration of the well-balancedness error over the domain
 l1_well_balance_error = Trixi.integrate_via_indices(u, mesh, equations, semi.solver,
                                                     semi.cache;


### PR DESCRIPTION
The latest CI tests after commit https://github.com/trixi-framework/TrixiShallowWater.jl/actions/runs/13095899259/job/36538157568, have failed the tests for `elixir_shallowwater_well_balanced_wet_dry.jl`, see: https://github.com/trixi-framework/TrixiShallowWater.jl/actions/runs/13095899259/job/36538157568#step:7:1655 

This might have been caused by a version update of `RecursiveArrayTools.jl` in `Trixi.jl`. This PR aims to fix the failing CI tests.