### PR TITLE
use GitHub token to authenticate downloads in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           PYTHON: ""
           TRIXI_TEST: ${{ matrix.trixi_test }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated downloads without strict rate limits
 
   test_coverage:
     if: "!contains(github.event.head_commit.message, 'skip ci')"


### PR DESCRIPTION
See https://github.com/trixi-framework/Trixi.jl/pull/2415. This will be active when the new version of Trixi.jl is released, which should occur in a few minutes.