### PR TITLE
Remove non-coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,16 @@ jobs:
           - dgmulti
           - p4est_2d
           - unit
+          - upstream
+        include:
+          - version: '1.10'
+            os: macos-latest
+            arch: aarch64
+            trixi_test: upstream
+          - version: '1.10'
+            os: windows-latest
+            arch: x64
+            trixi_test: upstream
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,6 @@ jobs:
           - dgmulti
           - p4est_2d
           - unit
-          - upstream
-        include:
-          - version: '1.10'
-            os: macos-latest
-            arch: aarch64
-            trixi_test: upstream
-          - version: '1.10'
-            os: windows-latest
-            arch: x64
-            trixi_test: upstream
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -74,65 +64,29 @@ jobs:
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Run tests without coverage
-        uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: false
-        env:
-          PYTHON: ""
-          TRIXI_TEST: ${{ matrix.trixi_test }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated downloads without strict rate limits
-
-  test_coverage:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: coverage - ${{ matrix.trixi_test }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1.10'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-        trixi_test:
-          - tree_1d
-          - tree_2d
-          - structured_2d
-          - unstructured_2d
-          - t8code_2d
-          - dgmulti
-          - p4est_2d
-          - unit
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - name: Run tests with coverage
+      - name: Run tests
         uses: julia-actions/julia-runtest@v1
         with:
           coverage: true
         env:
           PYTHON: ""
           TRIXI_TEST: ${{ matrix.trixi_test }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for authenticated downloads without strict rate limits
       - name: Process coverage results
         uses: julia-actions/julia-processcoverage@v1
+        if: ${{ !cancelled() }}
         with:
           directories: src,examples
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
+        if: ${{ !cancelled() }}
         with:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # now required for public repos
       - name: Upload coverage report to Coveralls
         uses: coverallsapp/github-action@v2
+        if: ${{ !cancelled() }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -140,8 +140,7 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 3.576650520299362,
                                 0.7495177590247986
                             ],
-                            tspan=(0.0, 0.025),
-                            coverage_override=(maxiters = 5,))
+                            tspan=(0.0, 0.025))
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         let
@@ -195,8 +194,7 @@ end # SWE
                                 3.292431218004944,
                                 3.3701108685790135,
                                 0.7495177590247986],
-                            tspan=(0.0, 0.01),
-                            coverage_override=(maxiters = 5,))
+                            tspan=(0.0, 0.01))
 
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
@@ -252,7 +250,6 @@ end # SWE
                                 1.324711724284584e-11,
                                 0.044079775502972124],
                             tspan=(0.0, 0.3),
-                            coverage_override=(maxiters = 5,),
                             atol=1e-10)
 
         # Ensure that we do not have excessive memory allocations

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -1012,8 +1012,7 @@ end # 2LSWE
                                 1.6653345369377348e-16
                             ],
                             tspan=(0.0, 0.25),
-                            atol=1e-9,
-                            coverage_override=(maxiters = 15,))
+                            atol=1e-9)
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         let

--- a/test/test_tree_2d.jl
+++ b/test/test_tree_2d.jl
@@ -433,9 +433,7 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 1.3874204364467229,
                                 1.3874204364467246,
                                 0.0
-                            ],
-                            # Increase iterations for coverage testing to trigger both inflow and outflow conditions
-                            coverage_override=(maxiters = 65, tspan = (0.0, 2.5)))
+                            ])
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         let
@@ -472,9 +470,7 @@ isdir(outdir) && rm(outdir, recursive = true)
                             boundary_conditions=(x_neg = boundary_condition_outflow,
                                                  x_pos = boundary_condition_inflow,
                                                  y_neg = boundary_condition_outflow,
-                                                 y_pos = boundary_condition_inflow),
-                            # Increase iterations for coverage testing to trigger both inflow and outflow conditions
-                            coverage_override=(maxiters = 65, tspan = (0.0, 2.5)))
+                                                 y_pos = boundary_condition_inflow))
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         let
@@ -879,10 +875,7 @@ end # 2LSWE
                                 0.026626783423061535,
                                 0.1016120899921184
                             ],
-                            tspan=(0.0, 0.25),
-                            # Increase iterations for coverage testing to trigger the
-                            # positivity limiter
-                            coverage_override=(maxiters = 130, tspan = (0.0, 1.5)))
+                            tspan=(0.0, 0.25))
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         let

--- a/test/test_trixi.jl
+++ b/test/test_trixi.jl
@@ -24,40 +24,12 @@ macro test_trixi_include(elixir, args...)
     rtol_default = sqrt(eps(RealT))
     local atol = get_kwarg(args, :atol, atol_default)
     local rtol = get_kwarg(args, :rtol, rtol_default)
-    local skip_coverage = get_kwarg(args, :skip_coverage, false)
-    local coverage_override = expr_to_named_tuple(get_kwarg(args, :coverage_override, :()))
-    if !(:maxiters in keys(coverage_override))
-        # maxiters in coverage_override defaults to 1
-        coverage_override = (; coverage_override..., maxiters = 1)
-    end
-
-    local cmd = string(Base.julia_cmd())
-    local coverage = occursin("--code-coverage", cmd) &&
-                     !occursin("--code-coverage=none", cmd)
 
     local kwargs = Pair{Symbol, Any}[]
     for arg in args
         if (arg.head == :(=) &&
-            !(arg.args[1] in (:l2, :linf, :atol, :rtol, :coverage_override, :skip_coverage))
-            && !(coverage && arg.args[1] in keys(coverage_override)))
+            !(arg.args[1] in (:l2, :linf, :atol, :rtol)))
             push!(kwargs, Pair(arg.args...))
-        end
-    end
-
-    if coverage
-        for key in keys(coverage_override)
-            push!(kwargs, Pair(key, coverage_override[key]))
-        end
-    end
-
-    if coverage && skip_coverage
-        return quote
-            if Trixi.mpi_isroot()
-                println("═"^100)
-                println("Skipping coverage test of ", $elixir)
-                println("═"^100)
-                println("\n\n")
-            end
         end
     end
 
@@ -79,7 +51,7 @@ macro test_trixi_include(elixir, args...)
         @test_nowarn_mod trixi_include(@__MODULE__, $elixir; $kwargs...) additional_ignore_content
 
         # if present, compare l2 and linf errors against reference values
-        if !$coverage && (!isnothing($l2) || !isnothing($linf))
+        if !isnothing($l2) || !isnothing($linf)
             l2_measured, linf_measured = analysis_callback(sol)
 
             if Trixi.mpi_isroot() && !isnothing($l2)


### PR DESCRIPTION
As explained in #108 the more complex splitting between coverage and non-coverage tests should be obsolete by now. This PR removes the non-coverage tests and is based on https://github.com/trixi-framework/Trixi.jl/pull/2254 (and https://github.com/trixi-framework/Trixi.jl/pull/2261).