### PR TITLE
Add CITATION.bib

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,7 @@
+@misc{winters2025trixi,
+  title={{T}rixi{S}hallow{W}ater.jl: {S}hallow water simulations with {T}rixi.jl},
+  author={Winters, Andrew R and Ersing, Patrick and Ranocha, Hendrik and Schlottke-Lakemper, Michael},
+  year={2025},
+  howpublished={\url{https://github.com/trixi-framework/TrixiShallowWater.jl}},
+  doi={10.5281/zenodo.15206520}
+}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ clone Trixi.jl, can be found in the
 [Development section](https://trixi-framework.github.io/TrixiShallowWater.jl/stable/development/)
 of the documentation.
 
+## Referencing
+You can directly refer to TrixiShallowWater.jl as
+
+```bibtex
+@misc{winters2025trixi,
+  title={{T}rixi{S}hallow{W}ater.jl: {S}hallow water simulations with {T}rixi.jl},
+  author={Winters, Andrew R and Ersing, Patrick and Ranocha, Hendrik and Schlottke-Lakemper, Michael},
+  year={2025},
+  howpublished={\url{https://github.com/trixi-framework/TrixiShallowWater.jl}},
+  doi={10.5281/zenodo.15206520}
+}
+```
+
 ## Authors
 TrixiShallowWater.jl is maintained by the
 [Trixi authors](https://github.com/trixi-framework/Trixi.jl/blob/main/AUTHORS.md).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,6 +53,19 @@ julia> using Pkg
 julia> Pkg.add(["Trixi", "Trixi2Vtk", "OrdinaryDiffEqLowStorageRK", "OrdinaryDiffEqSSPRK", "Plots"])
 ```
 
+## Referencing
+You can directly refer to TrixiShallowWater.jl as
+
+```bibtex
+@misc{winters2025trixi,
+  title={{T}rixi{S}hallow{W}ater.jl: {S}hallow water simulations with {T}rixi.jl},
+  author={Winters, Andrew R and Ersing, Patrick and Ranocha, Hendrik and Schlottke-Lakemper, Michael},
+  year={2025},
+  howpublished={\url{https://github.com/trixi-framework/TrixiShallowWater.jl}},
+  doi={10.5281/zenodo.15206520}
+}
+```
+
 ## Authors
 TrixiShallowWater.jl is maintained by the
 [Trixi authors](https://github.com/trixi-framework/Trixi.jl/blob/main/AUTHORS.md).


### PR DESCRIPTION
We would like to cite TrixiShallowWater.jl in a JOSS paper about [DispersiveShallowWater.jl](https://github.com/NumericalMathematics/DispersiveShallowWater.jl), but I saw there is no CITATION.bib file in the repo. So this PR adds one.