### PR TITLE
Use `@test_allocations` from TrixiTest.jl

### DIFF
--- a/test/test_dgmulti_1d.jl
+++ b/test/test_dgmulti_1d.jl
@@ -31,6 +31,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             9.43689570931383e-16,
                             2.220446049250313e-15
                         ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 end # DGMulti1D

--- a/test/test_dgmulti_2d.jl
+++ b/test/test_dgmulti_2d.jl
@@ -31,6 +31,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             0.12088391569555768,
                             9.325873406851315e-15
                         ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
@@ -50,6 +52,8 @@ end
                             0.567418412384793,
                             1.1102230246251565e-14
                         ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
@@ -71,6 +75,8 @@ end
                             0.06345896594568323,
                             3.398993309877696e-5
                         ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
@@ -94,6 +100,8 @@ end
                             0.010364657535841815,
                             2.042810365310288e-14
                         ])
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 end # DGMulti2D

--- a/test/test_p4est_2d.jl
+++ b/test/test_p4est_2d.jl
@@ -32,6 +32,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 1.2129488214718265e-5
                             ],
                             tspan=(0.0, 0.1))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -52,6 +54,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -71,6 +75,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.011669083581857587
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -91,6 +97,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -113,6 +121,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.7495177590247986
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # SWE
@@ -133,6 +143,8 @@ end # SWE
                                 0.41600528180178625],
                             tspan=(0.0, 0.25),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -154,6 +166,8 @@ end # SWE
                                 0.7495177590247986],
                             tspan=(0.0, 0.01))
 
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -177,6 +191,8 @@ end # SWE
                             tspan=(0.0, 0.25),
                             atol=5e-12)
 
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -196,6 +212,8 @@ end # SWE
                             tspan=(0.0, 0.3),
                             atol=1e-10)
 
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # MLSWE

--- a/test/test_structured_2d.jl
+++ b/test/test_structured_2d.jl
@@ -32,6 +32,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.00018196759554722775
                             ],
                             tspan=(0.0, 0.05))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -51,6 +53,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.4084298688001335
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -71,6 +75,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-12)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -90,6 +96,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.021790250683516296
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -109,6 +117,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 7.771561172376096e-16
                             ],
                             tspan=(0.0, 0.025), cells_per_dimension=(40, 40))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # SWE

--- a/test/test_t8code_2d.jl
+++ b/test/test_t8code_2d.jl
@@ -31,6 +31,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             1.2129488214718265e-5
                         ],
                         tspan=(0.0, 0.1))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 end # T8codeMesh2D

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -29,6 +29,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 1.7711213427919539
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -46,6 +48,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             initial_condition=initial_condition_weak_blast_wave,
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -59,6 +63,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             linf=[1.9999999999999996, 3.248036646353028e-14, 2.0],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -82,6 +88,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                                         hydrostatic_reconstruction_audusse_etal),
                                           flux_nonconservative_audusse_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -97,6 +105,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(flux_wintermeyer_etal,
                                           flux_nonconservative_wintermeyer_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -116,6 +126,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             tspan=(0.0, 0.25),
                             # Soften the tolerance as test results vary between different CPUs
                             atol=2000 * eps())
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -133,6 +145,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 9.098379777405796e-5
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -152,6 +166,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             tspan=(0.0, 0.025),
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -171,6 +187,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(flux_wintermeyer_etal,
                                           flux_nonconservative_wintermeyer_etal),
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -191,6 +209,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                               dissipation_roe),
                                           flux_nonconservative_fjordholm_etal),
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -208,6 +228,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 9.098379777405796e-5
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -228,6 +250,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                                         hydrostatic_reconstruction_audusse_etal),
                                           flux_nonconservative_audusse_etal),
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -247,6 +271,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             tspan=(0.0, 0.25),
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal),)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -267,6 +293,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal),
                             boundary_condition=boundary_condition_slip_wall)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -284,6 +312,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 5.195496810550537e-16
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -303,6 +333,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             boundary_conditions=(x_neg = boundary_condition_outflow,
                                                  x_pos = boundary_condition_inflow),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -320,6 +352,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 5.195496810550537e-16
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -337,6 +371,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 5.195496810550537e-16
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -354,6 +390,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.8646939843534251
                             ],
                             tspan=(0.0, 0.05))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -371,6 +409,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0, 0.05),
                             atol=1e-7) # see https://github.com/trixi-framework/Trixi.jl/issues/1617
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -388,6 +428,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 3.3306690738754696e-16
                             ],
                             tspan=(0.0, 0.05))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # SWE
@@ -409,6 +451,8 @@ end # SWE
                                 1.8196759554278685e-5
                             ],
                             tspan=(0.0, 0.05))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -429,6 +473,8 @@ end # SWE
                             ],
                             tspan=(0.0, 100.0),
                             atol=1e-12)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -447,6 +493,8 @@ end # SWE
                                 0.09999999999999983,
                                 0.10000000000000009
                             ],)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end
@@ -462,6 +510,8 @@ end
                                 0.02175023787351349,
                                 0.008212004668840978, 0.0008992474511784199],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -475,6 +525,8 @@ end
                                 0.005119880996670156,
                                 8.003199803957679e-16, 0.005119880996670666],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -490,6 +542,8 @@ end
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # 2LSWE
@@ -517,6 +571,8 @@ end # 2LSWE
                                 0.00021874455861881081
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -551,6 +607,8 @@ end # 2LSWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -588,6 +646,8 @@ end # 2LSWE
                                           FluxHydrostaticReconstruction(flux_nonconservative_ersing_etal,
                                                                         hydrostatic_reconstruction_ersing_etal)),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -613,6 +673,8 @@ end # 2LSWE
                                 0.005119880996670708
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -634,6 +696,8 @@ end # 2LSWE
                                 2.0
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -656,6 +720,8 @@ end # 2LSWE
                             ],
                             tspan=(0.0, 0.25),
                             perturbation=true)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -681,6 +747,8 @@ end # 2LSWE
                                 0.4999999999999993
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -706,6 +774,8 @@ end # 2LSWE
                                 0.4999999999999993
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -739,6 +809,8 @@ end # 2LSWE
                                 0.5
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -757,6 +829,8 @@ end # 2LSWE
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-5)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -775,6 +849,8 @@ end # 2LSWE
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-9)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # MLSWE
@@ -793,6 +869,8 @@ end # MLSWE
                                 0.0075032017005062235,
                                 4.7151297207559395e-5
                             ])
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -812,6 +890,8 @@ end # MLSWE
                             surface_flux=(FluxPlusDissipation(flux_central,
                                                               dissipation_roe),
                                           flux_nonconservative_ersing_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -838,6 +918,8 @@ end # MLSWE
                             surface_flux=(FluxPlusDissipation(flux_ersing_etal,
                                                               DissipationLocalLaxFriedrichs(max_abs_speed_naive)),
                                           flux_nonconservative_ersing_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -854,6 +936,8 @@ end # MLSWE
                                 2.957304143715833e-15,
                                 0.19999999999999998
                             ])
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -873,6 +957,8 @@ end # MLSWE
                             surface_flux=(FluxPlusDissipation(flux_ersing_etal,
                                                               dissipation_roe),
                                           flux_nonconservative_ersing_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -889,6 +975,8 @@ end # MLSWE
                                 0.009352017074210295,
                                 0.5499622869285822
                             ])
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -907,6 +995,8 @@ end # MLSWE
                             ],
                             surface_flux=(flux_ersing_etal,
                                           flux_nonconservative_ersing_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -923,6 +1013,8 @@ end # MLSWE
                                 0.9193314051729015,
                                 0.06639643395379602
                             ])
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # SWE-Exner

--- a/test/test_tree_2d.jl
+++ b/test/test_tree_2d.jl
@@ -31,6 +31,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 3.0
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -50,6 +52,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.1130620376156584
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -69,6 +73,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.1130620376156584
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -98,6 +104,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                                         hydrostatic_reconstruction_audusse_etal),
                                           flux_nonconservative_audusse_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -119,6 +127,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(flux_wintermeyer_etal,
                                           flux_nonconservative_wintermeyer_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -138,6 +148,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.0
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -157,6 +169,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.0001819675955490041
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -176,6 +190,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.0001819675955490041
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -197,6 +213,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             tspan=(0.0, 0.025),
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -218,6 +236,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             tspan=(0.0, 0.025),
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -239,6 +259,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(flux_wintermeyer_etal,
                                           flux_nonconservative_wintermeyer_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -261,6 +283,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                               dissipation_roe),
                                           flux_nonconservative_fjordholm_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -280,6 +304,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.021790250683516282
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -300,6 +326,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0, 0.025),
                             basis=LobattoLegendreBasis(3))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -318,6 +346,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 1.1301675764130437e-6
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -336,6 +366,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 1.3874204364467246,
                                 0.0
                             ])
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -366,6 +398,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                  x_pos = boundary_condition_inflow,
                                                  y_neg = boundary_condition_outflow,
                                                  y_pos = boundary_condition_inflow))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # SWE
@@ -385,6 +419,8 @@ end # SWE
                                 0.008407961775489636,
                                 3.361991620143279e-5],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -402,6 +438,8 @@ end # SWE
                                 7.520758026187046e-16,
                                 0.026474051138910267],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -428,6 +466,8 @@ end # SWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # 2LSWE
@@ -461,6 +501,8 @@ end # 2LSWE
                                 0.0004374891172380657
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -502,6 +544,8 @@ end # 2LSWE
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25),
                             atol=1e-11)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -537,6 +581,8 @@ end # 2LSWE
                                           FluxHydrostaticReconstruction(flux_nonconservative_ersing_etal,
                                                                         hydrostatic_reconstruction_ersing_etal)),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -574,6 +620,8 @@ end # 2LSWE
                                 0.026474051138910267
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -620,6 +668,8 @@ end # 2LSWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -651,6 +701,8 @@ end # 2LSWE
                                 0.10000011323773067
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -691,6 +743,8 @@ end # 2LSWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -722,6 +776,8 @@ end # 2LSWE
                                 0.1016120899921184
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # MLSWE

--- a/test/test_unstructured_2d.jl
+++ b/test/test_unstructured_2d.jl
@@ -31,6 +31,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.052861364219655
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -51,6 +53,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0f0, 0.25f0),
                             RealT=Float32)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -71,6 +75,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -101,6 +107,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                           flux_nonconservative_audusse_etal),
                             tspan=(0.0, 0.2),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -123,6 +131,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                           flux_nonconservative_wintermeyer_etal),
                             tspan=(0.0, 0.25),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -142,6 +152,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.6407324614341476e-5
                             ],
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -164,6 +176,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                                                         hydrostatic_reconstruction_audusse_etal),
                                           flux_nonconservative_audusse_etal),
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -185,6 +199,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(flux_wintermeyer_etal,
                                           flux_nonconservative_wintermeyer_etal),
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -206,6 +222,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal),
                             tspan=(0.0, 0.025))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -227,6 +245,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(FluxHLL(min_max_speed_naive),
                                           flux_nonconservative_fjordholm_etal),
                             atol=1e-10)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -249,6 +269,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             surface_flux=(FluxHydrostaticReconstruction(FluxHLL(min_max_speed_naive),
                                                                         hydrostatic_reconstruction_audusse_etal),
                                           flux_nonconservative_audusse_etal))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -268,6 +290,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 2.052861364219655
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -288,6 +312,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             ],
                             basis=LobattoLegendreBasis(3),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -307,6 +333,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                                 0.0
                             ],
                             tspan=(0.0, 3.0))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # SWE
@@ -325,6 +353,8 @@ end # SWE
                                 0.005884818649227186, 0.042658506561995546,
                                 0.014125956138838602, 2.5829318284764646e-5],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -342,6 +372,8 @@ end # SWE
                                 4.7000983997100496e-14,
                                 0.024280130945632732],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -367,6 +399,8 @@ end # SWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # 2LSWE
@@ -400,6 +434,8 @@ end # 2LSWE
                                 4.040896422807805e-6
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -440,6 +476,8 @@ end # 2LSWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -475,6 +513,8 @@ end # 2LSWE
                                           FluxHydrostaticReconstruction(flux_nonconservative_ersing_etal,
                                                                         hydrostatic_reconstruction_ersing_etal)),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -512,6 +552,8 @@ end # 2LSWE
                                 0.024280130945632836
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -558,6 +600,8 @@ end # 2LSWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -589,6 +633,8 @@ end # 2LSWE
                                 1.3458935664973586
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -620,6 +666,8 @@ end # 2LSWE
                                 0.10000000026183736
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -660,6 +708,8 @@ end # 2LSWE
                             surface_flux=(FluxLaxFriedrichs(max_abs_speed_naive),
                                           flux_nonconservative_ersing_etal),
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 
@@ -691,6 +741,8 @@ end # 2LSWE
                                 0.10003205938749304
                             ],
                             tspan=(0.0, 0.25))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
 end # MLSWE

--- a/test/test_upstream.jl
+++ b/test/test_upstream.jl
@@ -31,6 +31,8 @@ isdir(outdir) && rm(outdir, recursive = true)
                             1.7711213427919539
                         ],
                         tspan=(0.0, 0.25))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
@@ -49,6 +51,8 @@ end
                         ],
                         tspan=(0.0, 0.25),
                         boundary_condition=boundary_condition_slip_wall)
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 
@@ -70,6 +74,8 @@ end
                             0.021790250683516282
                         ],
                         tspan=(0.0, 0.025))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 # Unstructured2D
@@ -92,6 +98,8 @@ end
                         surface_flux=(FluxHydrostaticReconstruction(FluxHLL(min_max_speed_naive),
                                                                     hydrostatic_reconstruction_audusse_etal),
                                       flux_nonconservative_audusse_etal))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 # Structured2D
@@ -111,6 +119,8 @@ end
                             0.021790250683516296
                         ],
                         tspan=(0.0, 0.025))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 # P4estMesh2D
@@ -130,6 +140,8 @@ end
                             0.011669083581857587
                         ],
                         tspan=(0.0, 0.025))
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
     @test_allocations(Trixi.rhs!, semi, sol, 1000)
 end
 


### PR DESCRIPTION
Since TrixiTest.jl v0.1.3, it provides a macro `@test_allocations`, which can be used here to avoid a lot of code duplication.

<details>
<summary>For future reference, I used the following simple script:</summary>

```julia
for (root, _, files) in walkdir("test")
    for file in files
        if endswith(file, ".jl")
            filename = joinpath(root, file)
            (tmppath, tmpio) = mktemp()
            delete_next = false
            open(filename) do io
                for line in readlines(io)
                    if delete_next
                        delete_next = false
                        continue
                    end
                    if contains(line, "@test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) <")
                        new_line = replace(line, "    @test (@allocated Trixi.rhs!(du_ode, u_ode, semi, t)) <" => "@test_allocations(Trixi.rhs!, semi, sol,")
                        new_line *= ")"
                        delete_next = true
                        println(tmpio, new_line)
                    elseif contains(line, "# (e.g., from type instabilities)")
                        delete_next = true
                    elseif !(contains(line, "# Ensure that we do not have excessive memory allocations") ||
                             contains(line, "t = sol.t[end]") ||
                             contains(line, "u_ode = sol.u[end]") ||
                             contains(line, "du_ode = similar(u_ode)"))
                        println(tmpio, line)
                        delete_next = false
                    else
                        delete_next = false
                    end
                end
            end
            close(tmpio)
            mv(tmppath, filename, force = true)
        end
    end
end

```

</details>