### PR TITLE
Update formatting instructions for JuliaFormatter

### DIFF
--- a/docs/src/styleguide.md
+++ b/docs/src/styleguide.md
@@ -51,7 +51,7 @@ PRs that verify that running JuliaFormatter.jl again will not change the source 
 To format your contributions before created a PR (or, at least, before requesting a review
 of your PR), you need to install JuliaFormatter.jl first by running
 ```shell
-julia -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.60"))'
+julia -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.60")); Pkg.pin("JuliaFormatter")'
 ```
 You can then recursively format the core Julia files in the TrixiShallowWater.jl repo by executing
 ```shell


### PR DESCRIPTION
Analog to https://github.com/trixi-framework/Trixi.jl/pull/3042. This updates the formatting instructions and pins the version of JuliaFormatter.