### PR TITLE
Fix SWME flux function

### DIFF
--- a/src/equations/shallow_water_moments_1d.jl
+++ b/src/equations/shallow_water_moments_1d.jl
@@ -298,7 +298,7 @@ end
         j in eachmoment(equations),
         k in eachmoment(equations)
 
-        f_moments[i] += equations.A[i, j, k] * a[j] * a[k]
+        f_moments[i] += equations.A[i, j, k] * ha[j] * a[k]
     end
 
     return SVector{nmoments(equations) + 3, real(equations)}(f1, f2, f_moments..., 0)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -825,7 +825,7 @@ end
     equations_lin = ShallowWaterLinearizedMomentEquations1D(gravity = 9.81,
                                                             n_moments = 2)
 
-    u = SVector(1.0, 0.3, 0.15, 0.15, 0.1)
+    u = SVector(0.7, 0.3, 0.15, 0.15, 0.1)
 
     @test flux_careaga_etal(u, u, 1, equations) ≈ flux(u, 1, equations)
     @test flux_careaga_etal(u, u, 1, equations_lin) ≈ flux(u, 1, equations_lin)
@@ -843,7 +843,7 @@ end
 @testset "Consistency check for DissipationLaxFriedrichsEntropyVariables" begin
     @timed_testset "ShallowWaterEquations2D" begin
         equations = ShallowWaterEquations2D(gravity = 9.81)
-        u_ll = SVector(1.0, 0.3, 0.2, 0.2)
+        u_ll = SVector(0.7, 0.3, 0.2, 0.2)
         u_rr = SVector(1.5, 0.1, -0.1, 0.2)
         @test DissipationLaxFriedrichsEntropyVariables()(u_ll, u_rr, 1, equations) ≈
               DissipationLocalLaxFriedrichs()(u_ll, u_rr, 1, equations)
@@ -851,13 +851,13 @@ end
 
     @timed_testset "ShalloWaterMultiLayerEquations2D (single layer)" begin
         equations = ShallowWaterMultiLayerEquations2D(gravity = 9.81, rhos = (1.0))
-        u_ll = SVector(1.0, 0.3, 0.2, 0.1)
+        u_ll = SVector(0.7, 0.3, 0.2, 0.1)
         u_rr = SVector(1.5, 0.1, -0.1, 0.1)
         @test DissipationLaxFriedrichsEntropyVariables()(u_ll, u_rr, 1, equations) ≈
               DissipationLocalLaxFriedrichs()(u_ll, u_rr, 1, equations)
 
         # For a single layer the dissipation should be consistent with the 2D SWE
-        u_ll = SVector(1.0, 0.3, 0.2, 0.1)
+        u_ll = SVector(0.7, 0.3, 0.2, 0.1)
         u_rr = SVector(1.5, 0.1, -0.1, 0.2)
         equations_swe = ShallowWaterEquations2D(gravity = 9.81)
         @test DissipationLaxFriedrichsEntropyVariables()(u_ll, u_rr, 1, equations) ≈
@@ -868,7 +868,7 @@ end
         equations = ShallowWaterMomentEquations1D(gravity = 9.81, n_moments = 2)
         equations_lin = ShallowWaterLinearizedMomentEquations1D(gravity = 9.81,
                                                                 n_moments = 2)
-        u_ll = SVector(1.0, 0.3, 0.15, 0.15, 0.1)
+        u_ll = SVector(0.7, 0.3, 0.15, 0.15, 0.1)
         u_rr = SVector(1.5, 0.1, 0.25, 0.35, 0.1)
 
         diss_lf = DissipationLocalLaxFriedrichs()


### PR DESCRIPTION
This fixes a bug in the `flux` function for the `ShallowWaterMomentEquations`, which was missing a multiplication by the water height `h`.

This should have been covered by [unit testing](https://github.com/trixi-framework/TrixiShallowWater.jl/blob/b2f176a2d3b86a0656302504e6f188d45068189b/test/test_unit.jl#L828), but since we chose `u = SVector(1.0, 0.3, 0.15, 0.15, 0.1)`, the test did not fail. I have changed the test values to avoid this problem.
