### PR TITLE
Replace all instances of OBS with Note

### DIFF
--- a/examples/structured_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
+++ b/examples/structured_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
@@ -158,7 +158,7 @@ sol = solve(ode, SSPRK43(; stage_limiter!); dt = 1.0,
 # right of the discontinuous bottom topography `H0_lower = 1.5`.
 
 # Declare a special version of the function to compute the lake-at-rest error
-# OBS! The reference water height values are hardcoded for convenience.
+# Note: The reference water height values are hardcoded for convenience.
 function lake_at_rest_error_two_level(u, x, equations::ShallowWaterEquations2D)
     h, _, _, b = u
 

--- a/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
@@ -123,7 +123,7 @@ sol = solve(ode, SSPRK43(; stage_limiter!); dt = 1.0,
 # right of the discontinuous bottom topography `H0_lower = 1.5`.
 
 # Declare a special version of the function to compute the lake-at-rest error
-# OBS! The reference water height values are hardcoded for convenience.
+# Note: The reference water height values are hardcoded for convenience.
 function lake_at_rest_error_two_level(u, x, equations::ShallowWaterEquations1D)
     h, _, b = u
 

--- a/examples/tree_2d_dgsem/elixir_shallowwater_multilayer_well_balanced_wet_dry_sc_subcell.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_multilayer_well_balanced_wet_dry_sc_subcell.jl
@@ -159,7 +159,7 @@ sol = Trixi.solve(ode, Trixi.SimpleSSPRK33(stage_callbacks = stage_callbacks);
 # right of the discontinuous bottom topography `H0_lower = 1.5`.
 
 # Declare a special version of the function to compute the lake-at-rest error
-# OBS! The reference water height values are hardcoded for convenience.
+# Note: The reference water height values are hardcoded for convenience.
 function lake_at_rest_error_two_level(u, x, equations::ShallowWaterMultiLayerEquations2D)
     h, _, _, b = u
 

--- a/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
+++ b/examples/tree_2d_dgsem/elixir_shallowwater_well_balanced_wet_dry.jl
@@ -156,7 +156,7 @@ sol = solve(ode, SSPRK43(; stage_limiter!); dt = 1.0,
 # right of the discontinuous bottom topography `H0_lower = 1.5`.
 
 # Declare a special version of the function to compute the lake-at-rest error
-# OBS! The reference water height values are hardcoded for convenience.
+# Note: The reference water height values are hardcoded for convenience.
 function lake_at_rest_error_two_level(u, x, equations::ShallowWaterEquations2D)
     h, _, _, b = u
 

--- a/src/callbacks_step/amr_dg2d.jl
+++ b/src/callbacks_step/amr_dg2d.jl
@@ -43,7 +43,7 @@ function Trixi.refine!(u_ode::AbstractVector, adaptor, mesh::P4estMesh{2},
     old_n_elements = nelements(dg, cache)
     old_u_ode = copy(u_ode)
     old_inverse_jacobian = copy(cache.elements.inverse_jacobian)
-    # OBS! If we don't GC.@preserve old_u_ode and old_inverse_jacobian, they might be GC'ed
+    # Note: If we don't GC.@preserve old_u_ode and old_inverse_jacobian, they might be GC'ed
     GC.@preserve old_u_ode old_inverse_jacobian begin
         old_u = Trixi.wrap_array(old_u_ode, mesh, equations, dg, cache)
 
@@ -148,7 +148,7 @@ function Trixi.coarsen!(u_ode::AbstractVector, adaptor, mesh::P4estMesh{2},
     old_n_elements = nelements(dg, cache)
     old_u_ode = copy(u_ode)
     old_inverse_jacobian = copy(cache.elements.inverse_jacobian)
-    # OBS! If we don't GC.@preserve old_u_ode and old_inverse_jacobian, they might be GC'ed
+    # Note: If we don't GC.@preserve old_u_ode and old_inverse_jacobian, they might be GC'ed
     GC.@preserve old_u_ode old_inverse_jacobian begin
         old_u = Trixi.wrap_array(old_u_ode, mesh, equations, dg, cache)
 

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -15,8 +15,8 @@ isdir(outdir) && rm(outdir, recursive = true)
 #! format: noindent
 
 @timed_testset "Printing indicators/controllers" begin
-    # OBS! Constructing indicators/controllers using the parameters below doesn't make sense. It's
-    # just useful to run basic tests of `show` methods.
+    # Note: Constructing indicators/controllers using the parameters below doesn't make sense.
+    # It's just useful to run basic tests of `show` methods.
 
     indicator_hg_swe = IndicatorHennemannGassnerShallowWater(1.0, 0.0, true, "variable",
                                                              "cache")


### PR DESCRIPTION
This removes the text "OBS!" and replaces it with "Note:". The `p4est` tests will fail until #164 is merged.