### PR TITLE
Add 1D versions of AMR positivity limiter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ for human readability.
 - New equation types `ShallowWaterMomentEquations1D` and `ShallowWaterLinearizedMomentEquations1D` have been added. ([#128])
 - `ShallowWaterExner` extended to 2D on `TreeMesh`. ([#150])
 - Experimental support for rainfall & soil infiltration source terms for `ShallowWaterEquations1D` and `ShallowWaterEquations2D`. ([#158])
-- New variants of `limiter_shallow_water!` needed to ensure positivity preservation after coarsening and refinement steps in AMR via the keyword argument `limiter!` in `AMRCallback` ([#164]). For details on this callback see ([#2396](https://github.com/trixi-framework/Trixi.jl/pull/2396)) in Trixi.jl. This made the specialized `refine!` and `coarsen!` introduced in [#97] obsolete, which is why they were removed ([#164]).
+- New variants of `limiter_shallow_water!` needed to ensure positivity preservation after coarsening and refinement steps in AMR via the keyword argument `limiter!` in `AMRCallback` ([#164] and [#167]). For details on this callback see ([#2396](https://github.com/trixi-framework/Trixi.jl/pull/2396)) in Trixi.jl. This made the specialized `refine!` and `coarsen!` introduced in [#97] obsolete, which is why they were removed ([#164]).
 
 #### Changed
 - Velocity desingularization procedure has been moved into a distinct `VelocityDesingularization`

--- a/examples/tree_1d_dgsem/elixir_shallowwater_beach.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_beach.jl
@@ -11,7 +11,7 @@ equations = ShallowWaterEquations1D(gravity = 9.812)
 """
     initial_condition_beach(x, t, equations:: ShallowWaterEquations1D)
 
-Initial condition to simulate a wave running towards a beach and crashing. Difficult test
+Initial condition to simulate a wave propagating toward a beach and breaking. Difficult test
 including both wetting and drying in the domain using slip wall boundary conditions.
 The bottom topography is altered to be differentiable on the domain [0,8] and
 differs from the reference below.

--- a/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
@@ -1,0 +1,139 @@
+
+using OrdinaryDiffEqSSPRK, OrdinaryDiffEqLowStorageRK
+using Trixi
+using TrixiShallowWater
+
+###############################################################################
+# Semidiscretization of the shallow water equations
+
+equations = ShallowWaterEquations1D(gravity = 9.812)
+
+"""
+    initial_condition_beach(x, t, equations:: ShallowWaterEquations1D)
+
+Initial condition to simulate a wave running towards a beach and crashing. Difficult test
+including both wetting and drying in the domain using slip wall boundary conditions.
+The bottom topography is altered to be differentiable on the domain [0,8] and
+differs from the reference below.
+
+The water height and speed functions used here, are adapted from the initial condition
+found in section 5.2 of the paper:
+  - Andreas Bollermann, Sebastian Noelle, Maria Lukáčová-Medvid’ová (2011)
+    Finite volume evolution Galerkin methods for the shallow water equations with dry beds\n
+    [DOI: 10.4208/cicp.220210.020710a](https://dx.doi.org/10.4208/cicp.220210.020710a)
+"""
+function initial_condition_beach(x, t, equations::ShallowWaterEquations1D)
+    D = 1
+    delta = 0.02
+    gamma = sqrt((3 * delta) / (4 * D))
+    x_a = sqrt((4 * D) / (3 * delta)) * acosh(sqrt(20))
+
+    f = D + 40 * delta * sech(gamma * (8 * x[1] - x_a))^2
+
+    # steep curved beach
+    b = 0.01 + 99 / 409600 * 4^x[1]
+
+    if x[1] >= 6
+        H = b
+        v = 0.0
+    else
+        H = f
+        v = sqrt(equations.gravity / D) * H
+    end
+
+    # It is mandatory to shift the water level at dry areas to make sure the water height h
+    # stays positive. The system would not be stable for h set to a hard 0 due to division by h in
+    # the computation of velocity, e.g., (h v) / h. Therefore, a small dry state threshold
+    # with a default value of 500*eps() ≈ 1e-13 in double precision, is set in the constructor above
+    # for the ShallowWaterEquations and added to the initial condition if h = 0.
+    # This default value can be changed within the constructor call depending on the simulation setup.
+    H = max(H, b + equations.threshold_limiter)
+    return prim2cons(SVector(H, v, b), equations)
+end
+
+initial_condition = initial_condition_beach
+boundary_condition = boundary_condition_slip_wall
+
+###############################################################################
+# Get the DG approximation space
+
+volume_flux = (flux_wintermeyer_etal, flux_nonconservative_wintermeyer_etal)
+surface_flux = (FluxHydrostaticReconstruction(flux_hll_chen_noelle,
+                                              hydrostatic_reconstruction_chen_noelle),
+                flux_nonconservative_chen_noelle)
+
+basis = LobattoLegendreBasis(3)
+
+indicator_sc = IndicatorHennemannGassnerShallowWater(equations, basis,
+                                                     alpha_max = 0.5,
+                                                     alpha_min = 0.001,
+                                                     alpha_smooth = true,
+                                                     variable = waterheight_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg = volume_flux,
+                                                 volume_flux_fv = surface_flux)
+
+solver = DGSEM(basis, surface_flux, volume_integral)
+
+###############################################################################
+# Create the TreeMesh for the domain [0, 8]
+
+coordinates_min = 0.0
+coordinates_max = 8.0
+
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 5,
+                n_cells_max = 10_000,
+                periodicity = false)
+
+# create the semi discretization object
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions = boundary_condition)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 10.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 10000
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
+                                     save_analysis = false,
+                                     extra_analysis_integrals = (energy_kinetic,
+                                                                 energy_internal))
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(dt = 0.5,
+                                     save_initial_solution = true,
+                                     save_final_solution = true)
+
+amr_indicator = IndicatorLoehner(semi, variable = waterheight)
+
+amr_controller = ControllerThreeLevel(semi, amr_indicator,
+                                      base_level = 5,
+                                      max_level = 8, max_threshold = 0.05)
+
+# positivity limiter necessary for this example with wetting and drying and AMR
+positivity_limiter = PositivityPreservingLimiterShallowWater(variables = (waterheight,))
+
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval = 5,
+                           adapt_initial_condition = true,
+                           adapt_initial_condition_only_refine = true,
+                           limiter! = positivity_limiter)
+
+stepsize_callback = StepsizeCallback(cfl = 1.0)
+
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution,
+                        amr_callback, stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, SSPRK43(; stage_limiter! = positivity_limiter);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            adaptive = false,
+            ode_default_options()..., callback = callbacks);

--- a/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
@@ -82,7 +82,7 @@ coordinates_min = 0.0
 coordinates_max = 8.0
 
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 5,
+                initial_refinement_level = 6,
                 n_cells_max = 10_000,
                 periodicity = false)
 

--- a/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
@@ -11,7 +11,7 @@ equations = ShallowWaterEquations1D(gravity = 9.812)
 """
     initial_condition_beach(x, t, equations:: ShallowWaterEquations1D)
 
-Initial condition to simulate a wave running towards a beach and crashing. Difficult test
+Initial condition to simulate a wave propagating toward a beach and breaking. Difficult test
 including both wetting and drying in the domain using slip wall boundary conditions.
 The bottom topography is altered to be differentiable on the domain [0,8] and
 differs from the reference below.

--- a/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl
@@ -19,7 +19,7 @@ differs from the reference below.
 The water height and speed functions used here, are adapted from the initial condition
 found in section 5.2 of the paper:
   - Andreas Bollermann, Sebastian Noelle, Maria Lukáčová-Medvid’ová (2011)
-    Finite volume evolution Galerkin methods for the shallow water equations with dry beds\n
+    Finite volume evolution Galerkin methods for the shallow water equations with dry beds
     [DOI: 10.4208/cicp.220210.020710a](https://dx.doi.org/10.4208/cicp.220210.020710a)
 """
 function initial_condition_beach(x, t, equations::ShallowWaterEquations1D)
@@ -134,6 +134,6 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, sav
 # run the simulation
 
 sol = solve(ode, SSPRK43(; stage_limiter! = positivity_limiter);
-            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            dt = 1, # solve needs some value here but it will be overwritten by the stepsize_callback
             adaptive = false,
             ode_default_options()..., callback = callbacks);

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach.jl
@@ -12,7 +12,7 @@ equations = ShallowWaterMultiLayerEquations1D(gravity = 9.812, rhos = 1.0)
 """
     initial_condition_beach(x, t, equations:: ShallowWaterMultiLayerEquations1D)
 
-Initial condition to simulate a wave running towards a beach and crashing. Difficult test
+Initial condition to simulate a wave propagating toward a beach and breaking. Difficult test
 including both wetting and drying in the domain using slip wall boundary conditions.
 The bottom topography is altered to be differentiable on the domain [0,8] and
 differs from the reference below.

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -1,0 +1,149 @@
+
+using OrdinaryDiffEqSSPRK, OrdinaryDiffEqLowStorageRK
+using Trixi
+using TrixiShallowWater
+
+###############################################################################
+# Semidiscretization of the shallow water equations
+
+# By passing only a single value for rhos, the system recovers the standard shallow water equations
+equations = ShallowWaterMultiLayerEquations1D(gravity = 9.812, rhos = 1.0)
+
+"""
+    initial_condition_beach(x, t, equations:: ShallowWaterMultiLayerEquations1D)
+
+Initial condition to simulate a wave running towards a beach and crashing. Difficult test
+including both wetting and drying in the domain using slip wall boundary conditions.
+The bottom topography is altered to be differentiable on the domain [0,8] and
+differs from the reference below.
+
+The water height and speed functions used here, are adapted from the initial condition
+found in section 5.2 of the paper:
+  - Andreas Bollermann, Sebastian Noelle, Maria Lukáčová-Medvidová (2011)
+    Finite volume evolution Galerkin methods for the shallow water equations with dry beds\n
+    [DOI: 10.4208/cicp.220210.020710a](https://dx.doi.org/10.4208/cicp.220210.020710a)
+"""
+function initial_condition_beach(x, t, equations::ShallowWaterMultiLayerEquations1D)
+    D = 1
+    delta = 0.02
+    gamma = sqrt((3 * delta) / (4 * D))
+    x_a = sqrt((4 * D) / (3 * delta)) * acosh(sqrt(20))
+
+    f = D + 40 * delta * sech(gamma * (8 * x[1] - x_a))^2
+
+    # steep curved beach
+    b = 0.01 + 99 / 409600 * 4^x[1]
+
+    if x[1] >= 6
+        H = b
+        v = 0.0
+    else
+        H = f
+        v = sqrt(equations.gravity / D) * H
+    end
+
+    # It is mandatory to shift the water level at dry areas to make sure the water height h
+    # stays positive. The system would not be stable for h set to a hard 0 due to division by h in
+    # the computation of velocity, e.g., (h v) / h. Therefore, a small dry state threshold
+    # with a default value of 5*eps() ≈ 1e-15 in double precision, is set in the constructor above
+    # for the ShallowWaterMultiLayerEquations1D and added to the initial condition if h = 0.
+    # This default value can be changed within the constructor call depending on the simulation setup.
+    H = max(H, b + equations.threshold_limiter)
+    return prim2cons(SVector(H, v, b), equations)
+end
+
+initial_condition = initial_condition_beach
+boundary_condition = boundary_condition_slip_wall
+
+###############################################################################
+# Get the DG approximation space
+
+volume_flux = (flux_ersing_etal, flux_nonconservative_ersing_etal)
+# Up to Trixi.jl version 0.13.0, `max_abs_speed_naive` was used as the default wave speed estimate of
+# `DissipationLocalLaxFriedrichs(), i.e., `DissipationLocalLaxFriedrichs(max_abs_speed = max_abs_speed_naive)`.
+# In the `StepsizeCallback`, though, the less diffusive `max_abs_speeds` is employed which is consistent with `max_abs_speed`.
+# Thus, we exchanged in PR#2458 of Trixi.jl the default wave speed used in the LLF flux and dissipation operator to `max_abs_speed`.
+# To ensure that every example still runs we specify explicitly `DissipationLocalLaxFriedrichs(max_abs_speed_naive)`.
+# We remark, however, that the now default `max_abs_speed` is in general recommended due to compliance with the
+# `StepsizeCallback` (CFL-Condition) and less diffusion.
+surface_flux = (FluxHydrostaticReconstruction(FluxPlusDissipation(flux_ersing_etal,
+                                                                  DissipationLocalLaxFriedrichs(max_abs_speed_naive)),
+                                              hydrostatic_reconstruction_ersing_etal),
+                FluxHydrostaticReconstruction(flux_nonconservative_ersing_etal,
+                                              hydrostatic_reconstruction_ersing_etal))
+
+basis = LobattoLegendreBasis(3)
+
+indicator_sc = IndicatorHennemannGassnerShallowWater(equations, basis,
+                                                     alpha_max = 0.5,
+                                                     alpha_min = 0.001,
+                                                     alpha_smooth = true,
+                                                     variable = waterheight_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg = volume_flux,
+                                                 volume_flux_fv = surface_flux)
+
+solver = DGSEM(basis, surface_flux, volume_integral)
+
+###############################################################################
+# Create the TreeMesh for the domain [0, 8]
+
+coordinates_min = 0.0
+coordinates_max = 8.0
+
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 7,
+                n_cells_max = 10_000,
+                periodicity = false)
+
+# create the semi discretization object
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    boundary_conditions = boundary_condition)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+tspan = (0.0, 10.0)
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 1000
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
+                                     save_analysis = false,
+                                     extra_analysis_integrals = (energy_kinetic,
+                                                                 energy_internal))
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(dt = 0.5,
+                                     save_initial_solution = true,
+                                     save_final_solution = true)
+
+amr_indicator = IndicatorLoehner(semi, variable = waterheight_pressure)
+
+amr_controller = ControllerThreeLevel(semi, amr_indicator,
+                                      base_level = 5,
+                                      max_level = 8, max_threshold = 0.05)
+
+# positivity limiter necessary for this example with wetting and drying and AMR
+positivity_limiter = PositivityPreservingLimiterShallowWater(variables = (waterheight,))
+
+amr_callback = AMRCallback(semi, amr_controller,
+                           interval = 5,
+                           adapt_initial_condition = true,
+                           adapt_initial_condition_only_refine = true,
+                           limiter! = positivity_limiter)
+
+stepsize_callback = StepsizeCallback(cfl = 1.0)
+
+callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution,
+                        amr_callback, stepsize_callback)
+
+###############################################################################
+# run the simulation
+
+sol = solve(ode, SSPRK43(; stage_limiter! = positivity_limiter);
+            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            adaptive = false,
+            ode_default_options()..., callback = callbacks);

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -92,7 +92,7 @@ coordinates_min = 0.0
 coordinates_max = 8.0
 
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 7,
+                initial_refinement_level = 5,
                 n_cells_max = 10_000,
                 periodicity = false)
 
@@ -108,7 +108,7 @@ ode = semidiscretize(semi, tspan)
 
 summary_callback = SummaryCallback()
 
-analysis_interval = 1000
+analysis_interval = 10000
 analysis_callback = AnalysisCallback(semi, interval = analysis_interval,
                                      save_analysis = false,
                                      extra_analysis_integrals = (energy_kinetic,
@@ -120,11 +120,11 @@ save_solution = SaveSolutionCallback(dt = 0.5,
                                      save_initial_solution = true,
                                      save_final_solution = true)
 
-amr_indicator = IndicatorLoehner(semi, variable = waterheight_pressure)
+amr_indicator = IndicatorLoehner(semi, variable = entropy)
 
 amr_controller = ControllerThreeLevel(semi, amr_indicator,
                                       base_level = 5,
-                                      max_level = 8, max_threshold = 0.05)
+                                      max_level = 8, max_threshold = 0.25)
 
 # positivity limiter necessary for this example with wetting and drying and AMR
 positivity_limiter = PositivityPreservingLimiterShallowWater(variables = (waterheight,))

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -12,7 +12,7 @@ equations = ShallowWaterMultiLayerEquations1D(gravity = 9.812, rhos = 1.0)
 """
     initial_condition_beach(x, t, equations:: ShallowWaterMultiLayerEquations1D)
 
-Initial condition to simulate a wave running towards a beach and crashing. Difficult test
+Initial condition to simulate a wave propagating toward a beach and breaking. Difficult test
 including both wetting and drying in the domain using slip wall boundary conditions.
 The bottom topography is altered to be differentiable on the domain [0,8] and
 differs from the reference below.

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -20,7 +20,7 @@ differs from the reference below.
 The water height and speed functions used here, are adapted from the initial condition
 found in section 5.2 of the paper:
   - Andreas Bollermann, Sebastian Noelle, Maria Lukáčová-Medvidová (2011)
-    Finite volume evolution Galerkin methods for the shallow water equations with dry beds\n
+    Finite volume evolution Galerkin methods for the shallow water equations with dry beds
     [DOI: 10.4208/cicp.220210.020710a](https://dx.doi.org/10.4208/cicp.220210.020710a)
 """
 function initial_condition_beach(x, t, equations::ShallowWaterMultiLayerEquations1D)

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -144,6 +144,6 @@ callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, sav
 # run the simulation
 
 sol = solve(ode, SSPRK43(; stage_limiter! = positivity_limiter);
-            dt = 1.0, # solve needs some value here but it will be overwritten by the stepsize_callback
+            dt = 1, # solve needs some value here but it will be overwritten by the stepsize_callback
             adaptive = false,
             ode_default_options()..., callback = callbacks);

--- a/src/callbacks_stage/positivity_shallow_water_dg1d.jl
+++ b/src/callbacks_stage/positivity_shallow_water_dg1d.jl
@@ -9,8 +9,6 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{1},
                                 equations::ShallowWaterEquations1D,
                                 dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
     Trixi.@threaded for element in eachelement(dg, cache)
         # determine minimum value
         value_min = typemax(eltype(u))
@@ -22,41 +20,190 @@ function limiter_shallow_water!(u, threshold::Real, variable,
         # detect if limiting is necessary
         value_min < threshold || continue
 
-        # compute mean value
-        u_mean = zero(get_node_vars(u, equations, dg, 1, element))
-        for i in eachnode(dg)
-            u_node = get_node_vars(u, equations, dg, i, element)
-            u_mean += u_node * weights[i]
-        end
-        # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-        u_mean = u_mean / 2^ndims(mesh)
+        u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)
 
         # We compute the value directly with the mean values, as we assume that
         # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+        # However, we only need linear variables such as the `waterheight` here,
+        # where this is satisfied.
         value_mean = variable(u_mean, equations)
         theta = (value_mean - threshold) / (value_mean - value_min)
+
+        # This avoids the issue when `value_mean` is slightly smaller than `threshold`
+        # (e.g., due to finite precision effects in PositivityPreservingLimiterShallowWater),
+        # which results in invalid theta values smaller than 0. Note that min(1, theta)
+        # is not necessary since we are only enforcing lower bounds.
+        theta = max(0, theta)
+
         for i in eachnode(dg)
             u_node = get_node_vars(u, equations, dg, i, element)
 
-            # Cut off velocity in case that the waterheight is smaller than the threshold
-
-            h_node, h_v_node, b_node = u_node
-            h_mean, h_v_mean, _ = u_mean # b_mean is not used as b_node must not be overwritten
-
-            # Set them both to zero to apply linear combination correctly
-            if h_node <= threshold
-                h_v_node = zero(eltype(u))
-                h_v_mean = zero(eltype(u))
-            end
-
-            u_node = SVector(h_node, h_v_node, b_node)
-            u_mean = SVector(h_mean, h_v_mean, b_node)
+            # Cut off velocity in case that the water height is smaller than the threshold.
+            # Here the (possibly) cut off mean values are saved in a local variable
+            # to ensure that it only influences the current node `i`.
+            u_node, u_mean_local = zero_velocity_if_dry_node(u_node, u_mean, threshold,
+                                                             equations)
 
             # When velocity is cut off, the only averaged value is the waterheight,
             # because the velocity is set to zero and this value is passed.
             # Otherwise, the velocity is averaged, as well.
             # Note that the auxiliary bottom topography variable `b` is never limited.
-            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean,
+            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean_local,
+                           equations, dg, i, element)
+        end
+    end
+
+    # "Safety" application of the wet/dry thresholds over all the DG nodes
+    # on the current `element` after the limiting above in order to avoid dry nodes.
+    # If the value_mean < threshold before applying limiter, there
+    # could still be dry nodes afterwards due to logic of the limiting
+    velocity_desingularization!(u, mesh, equations, dg, cache)
+
+    return nothing
+end
+
+# Cut off velocity (and thus the momenta) in case that the water height
+# is smaller than the threshold.
+@inline function zero_velocity_if_dry_node(u_node, u_mean, threshold,
+                                           equations::ShallowWaterEquations1D)
+    h_node, h_v_node, b_node = u_node
+    # b_mean is not used as it must not be overwritten
+    h_mean, h_v_mean, _ = u_mean
+
+    if h_node <= threshold
+        h_v_node = zero(eltype(u_node))
+        h_v_mean = zero(eltype(u_node))
+    end
+
+    u_node = SVector(h_node, h_v_node, b_node)
+    u_mean_local = SVector(h_mean, h_v_mean, b_node)
+
+    return u_node, u_mean_local
+end
+
+# Modified version of the limiter used in the refinement step of the AMR callback.
+# To ensure admissibility after the refinement step, we compute a joint
+# limiting coefficient for all children elements and then limit against the
+# admissible mean value of the parent element.
+# This strategy is described in Remark 3 of the paper:
+# - Arpit Babbar, Praveen Chandrashekar (2025)
+#   Lax-Wendroff flux reconstruction on adaptive curvilinear meshes with
+#   error based time stepping for hyperbolic conservation laws
+#   [doi: 10.1016/j.jcp.2024.113622](https://doi.org/10.1016/j.jcp.2024.113622)
+function limiter_shallow_water!(u, threshold::Real, variable,
+                                mesh::Trixi.AbstractMesh{1},
+                                equations::ShallowWaterEquations1D, dg::DGSEM, cache,
+                                element_ids_new, u_mean_refined_elements)
+    @assert length(element_ids_new)==size(u_mean_refined_elements, 2) "The length of `element_ids_new` must match the second dimension of `u_mean_refined_elements`."
+
+    Trixi.@threaded for idx in eachindex(element_ids_new)
+        # Get the mean value from the parent element
+        u_mean = get_node_vars(u_mean_refined_elements, equations, dg, idx)
+
+        # We compute the value directly with the mean values, as we assume that
+        # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+        # However, we only need linear variables such as the `waterheight` here,
+        # where this is satisfied.
+        value_mean = variable(u_mean, equations)
+        theta = one(eltype(u)) # Limiting coefficient
+
+        # Iterate over the children of the current element to determine a joint limiting coefficient `theta`
+        for new_element_id in element_ids_new[idx]:(element_ids_new[idx] + 2^ndims(mesh) - 1)
+            # determine minimum value
+            value_min = typemax(eltype(u))
+            for i in eachnode(dg)
+                u_node = get_node_vars(u, equations, dg, i, new_element_id)
+                value_min = min(value_min, variable(u_node, equations))
+            end
+            value_min < threshold || continue # Detect if limiting is necessary
+
+            theta = min(theta, (value_mean - threshold) / (value_mean - value_min))
+        end
+
+        theta < 1 || continue # Check if limiting action is necessary
+
+        # This avoids the issue when `value_mean` is slightly smaller than `threshold`
+        # (e.g., due to finite precision effects in PositivityPreservingLimiterLiuZhang),
+        # which results in invalid theta values smaller than 0. Note that min(1, theta)
+        # is not necessary since we are only enforcing lower bounds.
+        theta = max(0, theta)
+
+        # Iterate again over the children to apply joint shifting
+        for new_element_id in element_ids_new[idx]:(element_ids_new[idx] + 2^ndims(mesh) - 1)
+            for i in eachnode(dg)
+                u_node = get_node_vars(u, equations, dg, i, new_element_id)
+
+                # Cut off velocity in case that the water height is smaller than the threshold.
+                # Here the (possibly) cut off mean values are saved in a local variable
+                # to ensure that it only influences the current node `i`.
+                u_node, u_mean_local = zero_velocity_if_dry_node(u_node, u_mean,
+                                                                 threshold, equations)
+
+                # When velocities are cut off, the only averaged value is the water height,
+                # because the velocities are set to zero and this value is passed.
+                # Otherwise, the velocities are averaged, as well.
+                # Note that the auxiliary bottom topography variable `b` is never limited.
+                set_node_vars!(u, theta * u_node + (1 - theta) * u_mean_local,
+                               equations, dg, i, new_element_id)
+            end
+        end
+    end
+
+    # "Safety" application of the wet/dry thresholds over all the DG nodes
+    # on the current `element` after the limiting above in order to avoid dry nodes.
+    # If the value_mean < threshold before applying limiter, there
+    # could still be dry nodes afterwards due to logic of the limiting
+    velocity_desingularization!(u, mesh, equations, dg, cache)
+
+    return nothing
+end
+
+# Modified version of the limiter used in the coarsening step of the AMR callback.
+# To ensure admissibility after the coarsening step, we apply the limiter to
+# the coarsened elements.
+function limiter_shallow_water!(u, threshold::Real, variable,
+                                mesh::Trixi.AbstractMesh{1},
+                                equations::ShallowWaterEquations1D, dg::DGSEM, cache,
+                                element_ids_new)
+    # Apply limiter to coarsened elements
+    Trixi.@threaded for element in element_ids_new
+        # determine minimum value
+        value_min = typemax(eltype(u))
+        for i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, element)
+            value_min = min(value_min, variable(u_node, equations))
+        end
+        value_min < threshold || continue # Detect if limiting is necessary
+
+        u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)
+
+        # We compute the value directly with the mean values, as we assume that
+        # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+        # However, we only need linear variables such as the `waterheight` here,
+        # where this is satisfied.
+        value_mean = variable(u_mean, equations)
+        theta = (value_mean - threshold) / (value_mean - value_min)
+
+        # This avoids the issue when `value_mean` is slightly smaller than `threshold`
+        # (e.g., due to finite precision effects in PositivityPreservingLimiterShallowWater),
+        # which results in invalid theta values smaller than 0. Note that min(1, theta)
+        # is not necessary since we are only enforcing lower bounds.
+        theta = max(0, theta)
+
+        for i in eachnode(dg)
+            u_node = get_node_vars(u, equations, dg, i, element)
+
+            # Cut off velocity in case that the water height is smaller than the threshold.
+            # Here the (possibly) cut off mean values are saved in a local variable
+            # to ensure that it only influences the current node `i`.
+            u_node, u_mean_local = zero_velocity_if_dry_node(u_node, u_mean, threshold,
+                                                             equations)
+
+            # When velocities are cut off, the only averaged value is the water height,
+            # because the velocities are set to zero and this value is passed.
+            # Otherwise, the velocities are averaged, as well.
+            # Note that the auxiliary bottom topography variable `b` is never limited.
+            set_node_vars!(u, theta * u_node + (1 - theta) * u_mean_local,
                            equations, dg, i, element)
         end
     end
@@ -77,8 +224,6 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{1},
                                 equations::ShallowWaterMultiLayerEquations1D,
                                 dg::DGSEM, cache)
-    @unpack weights = dg.basis
-
     Trixi.@threaded for element in eachelement(dg, cache)
         # Limit layerwise
         for m in eachlayer(equations)
@@ -92,20 +237,18 @@ function limiter_shallow_water!(u, threshold::Real, variable,
             # detect if limiting is necessary
             value_min < threshold - eps() || continue
 
-            # compute mean value
-            u_mean = zero(get_node_vars(u, equations, dg, 1, element))
-            for i in eachnode(dg)
-                u_node = get_node_vars(u, equations, dg, i, element)
-                u_mean += u_node * weights[i]
-            end
-
-            # note that the reference element is [-1,1]^ndims(dg), thus the weights sum to 2
-            u_mean = u_mean / 2^ndims(mesh)
+            u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)
 
             # We compute the value directly with the mean values.
-            # The waterheight `h` is limited independently in each layer.
+            # Note: The waterheight `h` is limited independently in each layer.
             value_mean = variable(u_mean, equations)[m]
             theta = (value_mean - threshold) / (value_mean - value_min)
+
+            # This avoids the issue when `value_mean` is slightly smaller than `threshold`
+            # (e.g., due to finite precision effects in PositivityPreservingLimiterShallowWater),
+            # which results in invalid theta values smaller than 0. Note that min(1, theta)
+            # is not necessary since we are only enforcing lower bounds.
+            theta = max(0, theta)
 
             for i in eachnode(dg)
                 u_node = get_node_vars(u, equations, dg, i, element)
@@ -121,8 +264,136 @@ function limiter_shallow_water!(u, threshold::Real, variable,
     # on the current `element` after the limiting above in order to avoid dry nodes.
     # If the value_mean < threshold before applying limiter, there
     # could still be dry nodes afterwards due to logic of the limiting.
-    # Additionally, a velocity desingularization is applied to avoid numerical 
+    # Additionally, a velocity desingularization is applied to avoid numerical
     # problems near dry states.
+    velocity_desingularization!(u, mesh, equations, dg, cache)
+
+    return nothing
+end
+
+# Modified version of the limiter used in the refinement step of the AMR callback.
+# To ensure admissibility after the refinement step, we compute a joint
+# limiting coefficient for all children elements and then limit against the
+# admissible mean value of the parent element.
+# This strategy is described in Remark 3 of the paper:
+# - Arpit Babbar, Praveen Chandrashekar (2025)
+#   Lax-Wendroff flux reconstruction on adaptive curvilinear meshes with
+#   error based time stepping for hyperbolic conservation laws
+#   [doi: 10.1016/j.jcp.2024.113622](https://doi.org/10.1016/j.jcp.2024.113622)
+function limiter_shallow_water!(u, threshold::Real, variable,
+                                mesh::Trixi.AbstractMesh{1},
+                                equations::ShallowWaterMultiLayerEquations1D, dg::DGSEM,
+                                cache,
+                                element_ids_new, u_mean_refined_elements)
+    @assert length(element_ids_new)==size(u_mean_refined_elements, 2) "The length of `element_ids_new` must match the second dimension of `u_mean_refined_elements`."
+
+    Trixi.@threaded for idx in eachindex(element_ids_new)
+        # Limit layerwise
+        for m in eachlayer(equations)
+            # Get the mean value from the parent element
+            u_mean = get_node_vars(u_mean_refined_elements, equations, dg, idx)
+
+            # We compute the value directly with the mean values, as we assume that
+            # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+            # However, we only need linear variables such as the `waterheight` here,
+            # where this is satisfied.
+            # Note: The waterheight `h` is limited independently in each layer.
+            value_mean = variable(u_mean, equations)[m]
+            theta = one(eltype(u)) # Limiting coefficient
+
+            # Iterate over the children of the current element to determine a joint limiting coefficient `theta`
+            for new_element_id in element_ids_new[idx]:(element_ids_new[idx] + 2^ndims(mesh) - 1)
+                # determine minimum value
+                value_min = typemax(eltype(u))
+                for i in eachnode(dg)
+                    u_node = get_node_vars(u, equations, dg, i, new_element_id)
+                    value_min = min(value_min, variable(u_node, equations)[m])
+                end
+                value_min < threshold - eps() || continue # Detect if limiting is necessary
+
+                theta = min(theta, (value_mean - threshold) / (value_mean - value_min))
+            end
+
+            theta < 1 || continue # Check if limiting action is necessary
+
+            # This avoids the issue when `value_mean` is slightly smaller than `threshold`
+            # (e.g., due to finite precision effects in PositivityPreservingLimiterShallowWater),
+            # which results in invalid theta values smaller than 0. Note that min(1, theta)
+            # is not necessary since we are only enforcing lower bounds.
+            theta = max(0, theta)
+
+            # Iterate again over the children to apply joint shifting
+            for new_element_id in element_ids_new[idx]:(element_ids_new[idx] + 2^ndims(mesh) - 1)
+                for i in eachnode(dg)
+                    u_node = get_node_vars(u, equations, dg, i, new_element_id)
+                    h_node = waterheight(u_node, equations)[m]
+                    h_mean = waterheight(u_mean, equations)[m]
+
+                    u[m, i, new_element_id] = theta * h_node + (1 - theta) * h_mean
+                end
+            end
+        end
+    end
+
+    # "Safety" application of the wet/dry thresholds over all the DG nodes
+    # on the current `element` after the limiting above in order to avoid dry nodes.
+    # If the value_mean < threshold before applying limiter, there
+    # could still be dry nodes afterwards due to logic of the limiting
+    velocity_desingularization!(u, mesh, equations, dg, cache)
+
+    return nothing
+end
+
+# Modified version of the limiter used in the coarsening step of the AMR callback.
+# To ensure admissibility after the coarsening step, we apply the limiter to
+# the coarsened elements.
+function limiter_shallow_water!(u, threshold::Real, variable,
+                                mesh::Trixi.AbstractMesh{1},
+                                equations::ShallowWaterMultiLayerEquations1D, dg::DGSEM,
+                                cache,
+                                element_ids_new)
+    # Apply limiter to coarsened elements
+    Trixi.@threaded for element in element_ids_new
+        # Limit layerwise
+        for m in eachlayer(equations)
+            # determine minimum value
+            value_min = typemax(eltype(u))
+            for i in eachnode(dg)
+                u_node = get_node_vars(u, equations, dg, i, element)
+                value_min = min(value_min, variable(u_node, equations)[m])
+            end
+            value_min < threshold - eps() || continue # Detect if limiting is necessary
+
+            u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)
+
+            # We compute the value directly with the mean values, as we assume that
+            # Jensen's inequality holds (e.g. pressure for compressible Euler equations).
+            # However, we only need linear variables such as the `waterheight` here,
+            # where this is satisfied.
+            # Note: The waterheight `h` is limited independently in each layer.
+            value_mean = variable(u_mean, equations)[m]
+            theta = (value_mean - threshold) / (value_mean - value_min)
+
+            # This avoids the issue when `value_mean` is slightly smaller than `threshold`
+            # (e.g., due to finite precision effects in PositivityPreservingLimiterShallowWater),
+            # which results in invalid theta values smaller than 0. Note that min(1, theta)
+            # is not necessary since we are only enforcing lower bounds.
+            theta = max(0, theta)
+
+            for i in eachnode(dg)
+                u_node = get_node_vars(u, equations, dg, i, element)
+                h_node = waterheight(u_node, equations)[m]
+                h_mean = waterheight(u_mean, equations)[m]
+
+                u[m, i, element] = theta * h_node + (1 - theta) * h_mean
+            end
+        end
+    end
+
+    # "Safety" application of the wet/dry thresholds over all the DG nodes
+    # on the current `element` after the limiting above in order to avoid dry nodes.
+    # If the value_mean < threshold before applying limiter, there
+    # could still be dry nodes afterwards due to logic of the limiting
     velocity_desingularization!(u, mesh, equations, dg, cache)
 
     return nothing

--- a/src/callbacks_stage/positivity_shallow_water_dg1d.jl
+++ b/src/callbacks_stage/positivity_shallow_water_dg1d.jl
@@ -235,6 +235,8 @@ function limiter_shallow_water!(u, threshold::Real, variable,
             end
 
             # detect if limiting is necessary
+            # TODO: Determine default thresholds for Float32
+            # (Currently default thresholds are only provided for Float64)
             value_min < threshold - eps() || continue
 
             u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)
@@ -309,6 +311,8 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                     u_node = get_node_vars(u, equations, dg, i, new_element_id)
                     value_min = min(value_min, variable(u_node, equations)[m])
                 end
+                # TODO: Determine default thresholds for Float32
+                # (Currently default thresholds are only provided for Float64)
                 value_min < threshold - eps() || continue # Detect if limiting is necessary
 
                 theta = min(theta, (value_mean - threshold) / (value_mean - value_min))
@@ -362,6 +366,8 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                 u_node = get_node_vars(u, equations, dg, i, element)
                 value_min = min(value_min, variable(u_node, equations)[m])
             end
+            # TODO: Determine default thresholds for Float32
+            # (Currently default thresholds are only provided for Float64)
             value_min < threshold - eps() || continue # Detect if limiting is necessary
 
             u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)

--- a/src/callbacks_stage/positivity_shallow_water_dg2d.jl
+++ b/src/callbacks_stage/positivity_shallow_water_dg2d.jl
@@ -237,6 +237,8 @@ function limiter_shallow_water!(u, threshold::Real, variable,
             end
 
             # detect if limiting is necessary
+            # TODO: Determine default thresholds for Float32
+            # (Currently default thresholds are only provided for Float64)
             value_min < threshold - eps() || continue
 
             u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)
@@ -309,6 +311,8 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                     u_node = get_node_vars(u, equations, dg, i, j, new_element_id)
                     value_min = min(value_min, variable(u_node, equations)[m])
                 end
+                # TODO: Determine default thresholds for Float32
+                # (Currently default thresholds are only provided for Float64)
                 value_min < threshold - eps() || continue # Detect if limiting is necessary
 
                 theta = min(theta, (value_mean - threshold) / (value_mean - value_min))
@@ -362,6 +366,8 @@ function limiter_shallow_water!(u, threshold::Real, variable,
                 u_node = get_node_vars(u, equations, dg, i, j, element)
                 value_min = min(value_min, variable(u_node, equations)[m])
             end
+            # TODO: Determine default thresholds for Float32
+            # (Currently default thresholds are only provided for Float64)
             value_min < threshold - eps() || continue # Detect if limiting is necessary
 
             u_mean = Trixi.compute_u_mean(u, element, mesh, equations, dg, cache)

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -477,14 +477,14 @@ isdir(outdir) && rm(outdir, recursive = true)
     @trixi_testset "elixir_shallowwater_beach_amr.jl" begin
         @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_beach_amr.jl"),
                             l2=[
-                                0.17873463476140447,
-                                1.2355762153364056,
-                                1.5922076606709238e-5
+                                0.17972307563501136,
+                                1.2380931771551882,
+                                9.520982270210175e-6
                             ],
                             linf=[
-                                0.8627122260331002,
-                                3.374742302102591,
-                                0.00010020743187588721
+                                0.8433772707725395,
+                                3.411753533148842,
+                                0.00011436764321715032
                             ],
                             tspan=(0.0, 0.05))
         # Ensure that we do not have excessive memory allocations

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -926,7 +926,9 @@ end # 2LSWE
                                 9.75692621468066,
                                 0.00010020743187588721
                             ],
-                            tspan=(0.0, 0.85)) # longer time for the positivity in coarsening to fire
+                            # longer time for the positivity in coarsening to fire
+                            tspan=(0.0, 0.85),
+                            atol=1e-4)
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -473,6 +473,24 @@ isdir(outdir) && rm(outdir, recursive = true)
         # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)
     end
+
+    @trixi_testset "elixir_shallowwater_beach_amr.jl" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR, "elixir_shallowwater_beach_amr.jl"),
+                            l2=[
+                                0.17873463476140447,
+                                1.2355762153364056,
+                                1.5922076606709238e-5
+                            ],
+                            linf=[
+                                0.8627122260331002,
+                                3.374742302102591,
+                                0.00010020743187588721
+                            ],
+                            tspan=(0.0, 0.05))
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
+        @test_allocations(Trixi.rhs!, semi, sol, 1000)
+    end
 end # SWE
 
 @testset "Shallow Water Quasi-1D" begin
@@ -890,6 +908,25 @@ end # 2LSWE
                             ],
                             tspan=(0.0, 0.25),
                             atol=1e-9)
+        # Ensure that we do not have excessive memory allocations
+        # (e.g., from type instabilities)
+        @test_allocations(Trixi.rhs!, semi, sol, 1000)
+    end
+
+    @trixi_testset "elixir_shallowwater_multilayer_beach_amr.jl" begin
+        @test_trixi_include(joinpath(EXAMPLES_DIR,
+                                     "elixir_shallowwater_multilayer_beach_amr.jl"),
+                            l2=[
+                                0.17996513221136373,
+                                1.2405243366861927,
+                                6.760918237808445e-6
+                            ],
+                            linf=[
+                                0.809798061281449,
+                                3.3967013076883963,
+                                0.00011674161724251064
+                            ],
+                            tspan=(0.0, 0.05))
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -928,7 +928,7 @@ end # 2LSWE
                             ],
                             # longer time for the positivity in coarsening to fire
                             tspan=(0.0, 0.85),
-                            atol=1e-4)
+                            atol=1e-2) # see https://github.com/trixi-framework/Trixi.jl/issues/1617
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -917,16 +917,16 @@ end # 2LSWE
         @test_trixi_include(joinpath(EXAMPLES_DIR,
                                      "elixir_shallowwater_multilayer_beach_amr.jl"),
                             l2=[
-                                0.17996513221136373,
-                                1.2405243366861927,
-                                6.760918237808445e-6
+                                1.22570505187571,
+                                4.9581241184022735,
+                                1.161315654378121e-5
                             ],
                             linf=[
-                                0.809798061281449,
-                                3.3967013076883963,
-                                0.00011674161724251064
+                                2.4550283772713746,
+                                9.75692621468066,
+                                0.00010020743187588721
                             ],
-                            tspan=(0.0, 0.05))
+                            tspan=(0.0, 0.85)) # longer time for the positivity in coarsening to fire
         # Ensure that we do not have excessive memory allocations
         # (e.g., from type instabilities)
         @test_allocations(Trixi.rhs!, semi, sol, 1000)


### PR DESCRIPTION
As discussed in #164 in [this thread](https://github.com/trixi-framework/TrixiShallowWater.jl/pull/164#discussion_r3557910110) the AMR capability is available for `TreeMesh1D` because no special mortar treatment is needed. It only requires new positivity limiter functions that ensure a positive water height after coarsening or refinement.

The first result result below is a beach run-up with four refinement levels found in `examples/tree_1d_dgsem/elixir_shallowwater_beach_amr.jl` at time `t = 1.25` is given below. The Löhner indicator is quite sensitive in the dry regions and a specialized AMR indicator may need implemented (outside the scope of this PR).

The second result below is a comparison with the fixed 128 element mesh version from `examples/tree_1d_dgsem/elixir_shallowwater_beach.jl` (dashed green line) against the AMR version (solid blue line) with element breakdown
```
 #elements:                  75
 ├── level 8:                40
 ├── level 7:                 6
 ├── level 6:                 7
 └── level 5:                22
```
both at time `t = 1.25`.

<img width="1282" height="776" alt="Screenshot 2026-07-10 at 14 10 26" src="https://github.com/user-attachments/assets/1ede42d3-955d-47cc-a6b5-d4a3225223a8" />

<img width="1285" height="780" alt="Screenshot 2026-07-10 at 14 10 03" src="https://github.com/user-attachments/assets/f9dd2336-1181-4acb-9ced-5a4583004a9a" />