### PR TITLE
Revert workaround related to Coveralls on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,6 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # now required for public repos
-      # Workaround for https://github.com/coverallsapp/github-action/issues/264
-      - name: Trust Coveralls Homebrew tap (Homebrew 6 requirement)
-        if: runner.os == 'macOS'
-        run: brew trust coverallsapp/coveralls
       - name: Upload coverage report to Coveralls
         uses: coverallsapp/github-action@v2
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Revert the workaround introduced in #162 since the underlying issue has been resolved in the coveralls GitHub action.