### PR TITLE
Mark AMR specific limiter routines as experimental

### DIFF
--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -134,7 +134,7 @@ amr_callback = AMRCallback(semi, amr_controller,
                            adapt_initial_condition_only_refine = true,
                            limiter! = positivity_limiter)
 
-stepsize_callback = StepsizeCallback(cfl = 1.0)
+stepsize_callback = StepsizeCallback(cfl = 0.9)
 
 callbacks = CallbackSet(summary_callback, analysis_callback, alive_callback, save_solution,
                         amr_callback, stepsize_callback)

--- a/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
+++ b/examples/tree_1d_dgsem/elixir_shallowwater_multilayer_beach_amr.jl
@@ -92,7 +92,7 @@ coordinates_min = 0.0
 coordinates_max = 8.0
 
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 5,
+                initial_refinement_level = 8,
                 periodicity = false)
 
 # create the semi discretization object

--- a/src/callbacks_stage/positivity_shallow_water.jl
+++ b/src/callbacks_stage/positivity_shallow_water.jl
@@ -66,6 +66,9 @@ function (limiter!::PositivityPreservingLimiterShallowWater)(u_ode, integrator,
 end
 
 # Version used by the AMR callback
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function (limiter!::PositivityPreservingLimiterShallowWater)(u, mesh, equations, solver,
                                                              cache, args...)
     limiter_shallow_water!(u, limiter!.variables, mesh, equations,

--- a/src/callbacks_stage/positivity_shallow_water_dg1d.jl
+++ b/src/callbacks_stage/positivity_shallow_water_dg1d.jl
@@ -90,6 +90,9 @@ end
 #   Lax-Wendroff flux reconstruction on adaptive curvilinear meshes with
 #   error based time stepping for hyperbolic conservation laws
 #   [doi: 10.1016/j.jcp.2024.113622](https://doi.org/10.1016/j.jcp.2024.113622)
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{1},
                                 equations::ShallowWaterEquations1D, dg::DGSEM, cache,
@@ -123,7 +126,7 @@ function limiter_shallow_water!(u, threshold::Real, variable,
         theta < 1 || continue # Check if limiting action is necessary
 
         # This avoids the issue when `value_mean` is slightly smaller than `threshold`
-        # (e.g., due to finite precision effects in PositivityPreservingLimiterLiuZhang),
+        # (e.g., due to finite precision effects in PositivityPreservingLimiterShallowWater),
         # which results in invalid theta values smaller than 0. Note that min(1, theta)
         # is not necessary since we are only enforcing lower bounds.
         theta = max(0, theta)
@@ -161,6 +164,9 @@ end
 # Modified version of the limiter used in the coarsening step of the AMR callback.
 # To ensure admissibility after the coarsening step, we apply the limiter to
 # the coarsened elements.
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{1},
                                 equations::ShallowWaterEquations1D, dg::DGSEM, cache,
@@ -282,6 +288,9 @@ end
 #   Lax-Wendroff flux reconstruction on adaptive curvilinear meshes with
 #   error based time stepping for hyperbolic conservation laws
 #   [doi: 10.1016/j.jcp.2024.113622](https://doi.org/10.1016/j.jcp.2024.113622)
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{1},
                                 equations::ShallowWaterMultiLayerEquations1D, dg::DGSEM,
@@ -351,6 +360,9 @@ end
 # Modified version of the limiter used in the coarsening step of the AMR callback.
 # To ensure admissibility after the coarsening step, we apply the limiter to
 # the coarsened elements.
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{1},
                                 equations::ShallowWaterMultiLayerEquations1D, dg::DGSEM,

--- a/src/callbacks_stage/positivity_shallow_water_dg2d.jl
+++ b/src/callbacks_stage/positivity_shallow_water_dg2d.jl
@@ -92,6 +92,9 @@ end
 #   Lax-Wendroff flux reconstruction on adaptive curvilinear meshes with
 #   error based time stepping for hyperbolic conservation laws
 #   [doi: 10.1016/j.jcp.2024.113622](https://doi.org/10.1016/j.jcp.2024.113622)
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{2},
                                 equations::ShallowWaterEquations2D, dg::DGSEM, cache,
@@ -163,6 +166,9 @@ end
 # Modified version of the limiter used in the coarsening step of the AMR callback.
 # To ensure admissibility after the coarsening step, we apply the limiter to
 # the coarsened elements.
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{2},
                                 equations::ShallowWaterEquations2D, dg::DGSEM, cache,
@@ -282,6 +288,9 @@ end
 #   Lax-Wendroff flux reconstruction on adaptive curvilinear meshes with
 #   error based time stepping for hyperbolic conservation laws
 #   [doi: 10.1016/j.jcp.2024.113622](https://doi.org/10.1016/j.jcp.2024.113622)
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{2},
                                 equations::ShallowWaterMultiLayerEquations2D, dg::DGSEM,
@@ -351,6 +360,9 @@ end
 # Modified version of the limiter used in the coarsening step of the AMR callback.
 # To ensure admissibility after the coarsening step, we apply the limiter to
 # the coarsened elements.
+#
+# !!! warning "Experimental code"
+#     This is an experimental feature and may change in future releases.
 function limiter_shallow_water!(u, threshold::Real, variable,
                                 mesh::Trixi.AbstractMesh{2},
                                 equations::ShallowWaterMultiLayerEquations2D, dg::DGSEM,

--- a/test/test_tree_1d.jl
+++ b/test/test_tree_1d.jl
@@ -917,14 +917,14 @@ end # 2LSWE
         @test_trixi_include(joinpath(EXAMPLES_DIR,
                                      "elixir_shallowwater_multilayer_beach_amr.jl"),
                             l2=[
-                                1.22570505187571,
-                                4.9581241184022735,
-                                1.161315654378121e-5
+                                1.2279477255799136,
+                                4.956544639816718,
+                                7.1665061086485795e-6
                             ],
                             linf=[
-                                2.4550283772713746,
-                                9.75692621468066,
-                                0.00010020743187588721
+                                2.443603067275829,
+                                9.77064103923972,
+                                0.000116781021658241
                             ],
                             # longer time for the positivity in coarsening to fire
                             tspan=(0.0, 0.85),


### PR DESCRIPTION
The AMR pipeline is still experimental. The specialized limiter routines for coarsening and refinement introduced in #164 and #167 are now marked as such.

Related to #176 